### PR TITLE
fix: don't install when `make` is run with no target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 PREFIX?=/usr
 
+default:
+	@echo 'Run `make install` to install'
+
 install:
 	cp -f cowfetch $(PREFIX)/bin/cowfetch
 	chmod +x $(PREFIX)/bin/cowfetch
 uninstall:
 	rm -f $(PREFIX)/bin/cowfetch
 
-.PHONY: install uninstall
+.PHONY: default install uninstall


### PR DESCRIPTION
Conventionally, `make` builds the project and `make install` installs it. External side effects of `make` alone are unexpected. Therefore, change it to a no-op that prints a helpful message.